### PR TITLE
Fixes #2

### DIFF
--- a/probableparsing/__init__.py
+++ b/probableparsing/__init__.py
@@ -1,5 +1,5 @@
 class RepeatedLabelError(Exception) :
-    MESSAGE ='''
+    MESSAGE = u'''
 ERROR: Unable to tag this string because more than one area of the string has the same label
 
 ORIGINAL STRING:  {original_string}
@@ -10,7 +10,7 @@ When this error is raised, it's likely that either (1) the string is not a valid
 
 To report an error in labeling a valid name, open an issue at {repo_url} - it'll help us continue to improve probablepeople!'''
 
-    DOCS_MESSAGE = '''
+    DOCS_MESSAGE = u'''
 
 For more information, see the documentation at {docs_url}'''
     


### PR DESCRIPTION
This should make it so that if there are non-ascii characters in the text throwing the original exception, we don't throw an exception while trying to convert the non-ascii characters in order to throw the original exception about the non-ascii strings not parsing properly. 