### PR TITLE
UnicodeEncodeError exception

### DIFF
--- a/probableparsing/__init__.py
+++ b/probableparsing/__init__.py
@@ -1,5 +1,5 @@
 class RepeatedLabelError(Exception) :
-    MESSAGE ='''
+    MESSAGE = u'''
 ERROR: Unable to tag this string because more than one area of the string has the same label
 
 ORIGINAL STRING:  {original_string}
@@ -10,7 +10,7 @@ When this error is raised, it's likely that either (1) the string is not a valid
 
 To report an error in labeling a valid name, open an issue at {repo_url} - it'll help us continue to improve probablepeople!'''
 
-    DOCS_MESSAGE = '''
+    DOCS_MESSAGE = u'''
 
 For more information, see the documentation at {docs_url}'''
     
@@ -26,5 +26,9 @@ For more information, see the documentation at {docs_url}'''
         self.original_string = original_string
         self.parsed_string = parsed_string
 
-    def __str__(self) :
+    def __str__(self):
+        return unicode(self).encode('utf-8')
+
+    def __unicode__(self) :
         return self.message
+    


### PR DESCRIPTION
Resolves issue where calling exception raises UnicodeEncodeError if unicode characters in one of the parameters. This is particularly prominent where using probablepeople.tag on foreign names raises RepeatedLabelError.