### PR TITLE
Add repeated label for access when handling exception

### DIFF
--- a/probableparsing/__init__.py
+++ b/probableparsing/__init__.py
@@ -25,6 +25,7 @@ For more information, see the documentation at {docs_url}'''
 
         self.original_string = original_string
         self.parsed_string = parsed_string
+        self.repeated_label = repeated_label
 
     def __str__(self) :
         return self.message


### PR DESCRIPTION
This allows me to raise a single-line error of my own instead of the large amount of text stored in the exception message.

```
try:
    comp, addr_type = usaddress.tag(address, tag_mapping=usaddress_tag_mapping)
except usaddress.RepeatedLabelError as e:
    raise AddressStemError(f"RepeatedLabelError: {e.repeated_label} / {e.original_string} -> {e.parsed_string}")
```

That is all. Thanks for the awesome module (usaddress).